### PR TITLE
fix(ci): bump Ruby from 3.1 to 3.3 for sass-embedded compat

### DIFF
--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -37,7 +37,7 @@ jobs:
         # https://github.com/ruby/setup-ruby/releases/tag/v1.207.0
         uses: ruby/setup-ruby@4a9ddd6f338a97768b8006bf671dfbad383215f4
         with:
-          ruby-version: '3.1' # Not needed with a .ruby-version file
+          ruby-version: '3.3' # Opdateret: sass-embedded kræver Ruby >= 3.2
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
           cache-version: 0 # Increment this number if you need to re-download cached gems
       - name: Setup Pages


### PR DESCRIPTION
## Problem

Build fails on main after the runner cache was invalidated:

```
sass-embedded-1.93.2 requires ruby version >= 3.2, incompatible with the current version, 3.1.6
```

The cache previously masked the incompatibility – with the cache gone, gems are installed fresh and the conflict surfaces.

## Solution

Bump `ruby-version: '3.3'` in `.github/workflows/jekyll.yml`.